### PR TITLE
[IVT-1002] Auth overrides

### DIFF
--- a/ckanext/collaborators/logic/action.py
+++ b/ckanext/collaborators/logic/action.py
@@ -160,7 +160,7 @@ def dataset_collaborator_list_for_user(context, data_dict):
     :type id: string
     :param capacity: (optional) If provided, only datasets where the user has this
         capacity are returned
-    :type id: string
+    :type capacity: string
 
     :returns: a list of datasets, each a dict including the dataset id, the
         capacity and the last modified date

--- a/ckanext/collaborators/logic/auth.py
+++ b/ckanext/collaborators/logic/auth.py
@@ -3,7 +3,7 @@ from ckan.authz import has_user_permission_for_group_or_org
 
 
 
-def _auth_collaborator(context, data_dict):
+def _auth_collaborator(context, data_dict, message):
     user = context['user']
 
     dataset = toolkit.get_action('package_show')(
@@ -17,8 +17,7 @@ def _auth_collaborator(context, data_dict):
             owner_org, user, 'membership'):
         return {
             'success': False,
-            'msg': toolkit._(
-                'User %s not authorized to add members to this dataset') % user}
+            'msg': toolkit._(message) % user}
 
     return {'success': True}
 
@@ -29,7 +28,8 @@ def dataset_collaborator_create(context, data_dict):
     The current implementation restricts this ability to Administrators of the
     organization the dataset belongs to.
     '''
-    return _auth_collaborator(context, data_dict)
+    return _auth_collaborator(context, data_dict,
+        'User %s not authorized to add members to this dataset')
 
 
 def dataset_collaborator_delete(context, data_dict):
@@ -38,7 +38,8 @@ def dataset_collaborator_delete(context, data_dict):
     The current implementation restricts this ability to Administrators of the
     organization the dataset belongs to.
     '''
-    return _auth_collaborator(context, data_dict)
+    return _auth_collaborator(context, data_dict,
+        'User %s not authorized to remove members from this dataset')
 
 
 def dataset_collaborator_list(context, data_dict):
@@ -47,5 +48,16 @@ def dataset_collaborator_list(context, data_dict):
     The current implementation restricts this ability to Administrators of the
     organization the dataset belongs to.
     '''
-    return _auth_collaborator(context, data_dict)
+    return _auth_collaborator(context, data_dict,
+        'User %s not authorized to list members from this dataset')
 
+
+def dataset_collaborator_list_for_user(context, data_dict):
+    '''Checks if a user is allowed to list all datasets a user is acollaborator in
+
+    The current implementation restricts to the own users themselves.
+    '''
+    user_obj = context.get('auth_user_obj')
+    if user_obj and data_dict.get('id') in (user_obj.name, user_obj.id):
+        return {'success': True}
+    return {'success': False}

--- a/ckanext/collaborators/logic/auth.py
+++ b/ckanext/collaborators/logic/auth.py
@@ -72,12 +72,14 @@ def package_update(context, data_dict):
 
     result = core_package_update(context, data_dict)
 
-    if not result['success']:
-        user_name = context['user']
-        dataset = get_package_object(context, data_dict)
+    if result['success']:
+        return result
 
-        datasets = toolkit.get_action(
-            'dataset_collaborator_list_for_user')(
-                context, {'id': user_name, 'capacity': 'editor'})
-        return {
-            'success': dataset.id in [d['dataset_id'] for d in datasets]}
+    user_name = context['user']
+    dataset = get_package_object(context, data_dict)
+
+    datasets = toolkit.get_action(
+        'dataset_collaborator_list_for_user')(
+            context, {'id': user_name, 'capacity': 'editor'})
+    return {
+        'success': dataset.id in [d['dataset_id'] for d in datasets]}

--- a/ckanext/collaborators/logic/auth.py
+++ b/ckanext/collaborators/logic/auth.py
@@ -55,7 +55,7 @@ def dataset_collaborator_list(context, data_dict):
 
 
 def dataset_collaborator_list_for_user(context, data_dict):
-    '''Checks if a user is allowed to list all datasets a user is acollaborator in
+    '''Checks if a user is allowed to list all datasets a user is a collaborator in
 
     The current implementation restricts to the own users themselves.
     '''

--- a/ckanext/collaborators/plugin.py
+++ b/ckanext/collaborators/plugin.py
@@ -50,6 +50,7 @@ to create the database tables:
             'dataset_collaborator_delete': auth.dataset_collaborator_delete,
             'dataset_collaborator_list': auth.dataset_collaborator_list,
             'dataset_collaborator_list_for_user': auth.dataset_collaborator_list_for_user,
+            'package_update': auth.package_update,
         }
 
     # IPermissionLabels

--- a/ckanext/collaborators/plugin.py
+++ b/ckanext/collaborators/plugin.py
@@ -31,17 +31,21 @@ to create the database tables:
         toolkit.add_resource('fanstatic', 'collaborators')
 
     # IActions
+
     def get_actions(self):
         return {
             'dataset_collaborator_create': action.dataset_collaborator_create,
             'dataset_collaborator_delete': action.dataset_collaborator_delete,
             'dataset_collaborator_list': action.dataset_collaborator_list,
+            'dataset_collaborator_list_for_user': action.dataset_collaborator_list_for_user,
         }
 
     # IAuthFunctions
+
     def get_auth_functions(self):
         return {
             'dataset_collaborator_create': auth.dataset_collaborator_create,
             'dataset_collaborator_delete': auth.dataset_collaborator_delete,
             'dataset_collaborator_list': auth.dataset_collaborator_list,
+            'dataset_collaborator_list_for_user': auth.dataset_collaborator_list_for_user,
         }

--- a/ckanext/collaborators/tests/test_action.py
+++ b/ckanext/collaborators/tests/test_action.py
@@ -178,3 +178,71 @@ class TestCollaboratorsActions(FunctionalTestBase):
         assert_raises(toolkit.ValidationError, helpers.call_action,
             'dataset_collaborator_list',
             id=dataset['id'], user_id=user['id'], capacity=capacity)
+
+    def test_list_for_user(self):
+
+        dataset1 = factories.Dataset()
+        dataset2 = factories.Dataset()
+        user = factories.User()
+        capacity1 = 'editor'
+        capacity2 = 'member'
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset1['id'], user_id=user['id'], capacity=capacity1)
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset2['id'], user_id=user['id'], capacity=capacity2)
+
+        datasets = helpers.call_action(
+            'dataset_collaborator_list_for_user',
+            id=user['id'])
+
+        assert_equals(len(datasets), 2)
+
+        assert_equals(datasets[0]['dataset_id'], dataset1['id'])
+        assert_equals(datasets[0]['capacity'], capacity1)
+
+        assert_equals(datasets[1]['dataset_id'], dataset2['id'])
+        assert_equals(datasets[1]['capacity'], capacity2)
+
+    def test_list_for_user_with_capacity(self):
+
+        dataset1 = factories.Dataset()
+        dataset2 = factories.Dataset()
+        user = factories.User()
+        capacity1 = 'editor'
+        capacity2 = 'member'
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset1['id'], user_id=user['id'], capacity=capacity1)
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset2['id'], user_id=user['id'], capacity=capacity2)
+
+        datasets = helpers.call_action(
+            'dataset_collaborator_list_for_user',
+            id=user['id'], capacity='editor')
+
+
+        assert_equals(len(datasets), 1)
+
+        assert_equals(datasets[0]['dataset_id'], dataset1['id'])
+        assert_equals(datasets[0]['capacity'], capacity1)
+
+    def test_list_for_user_user_not_found(self):
+
+        assert_raises(toolkit.ObjectNotFound, helpers.call_action,
+            'dataset_collaborator_list_for_user',
+            id='xxx')
+
+    def test_list_for_user_wrong_capacity(self):
+        user = factories.User()
+        capacity = 'unknown'
+
+        assert_raises(toolkit.ValidationError, helpers.call_action,
+            'dataset_collaborator_list_for_user',
+            id=user['id'], capacity=capacity)

--- a/ckanext/collaborators/tests/test_action.py
+++ b/ckanext/collaborators/tests/test_action.py
@@ -246,3 +246,62 @@ class TestCollaboratorsActions(FunctionalTestBase):
         assert_raises(toolkit.ValidationError, helpers.call_action,
             'dataset_collaborator_list_for_user',
             id=user['id'], capacity=capacity)
+
+
+class TestCollaboratorsSearch(FunctionalTestBase):
+
+    def test_search_results_editor(self):
+
+        org = factories.Organization()
+        dataset1 = factories.Dataset(
+            name='test1', private=True, owner_org=org['id'])
+        dataset2 = factories.Dataset(name='test2')
+
+        user = factories.User()
+        context = {'user': user['name']}
+
+        results = toolkit.get_action('package_search')(context,
+                {'q':'*:*', 'include_private':True})
+
+        assert_equals(results['count'], 1)
+        assert_equals(results['results'][0]['id'], dataset2['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset1['id'], user_id=user['id'], capacity='editor')
+
+        results = toolkit.get_action('package_search')(context,
+                {'q':'*:*', 'include_private':True, 'sort': 'name asc'})
+
+        assert_equals(results['count'], 2)
+
+        assert_equals(results['results'][0]['id'], dataset1['id'])
+        assert_equals(results['results'][1]['id'], dataset2['id'])
+
+    def test_search_results_member(self):
+
+        org = factories.Organization()
+        dataset1 = factories.Dataset(
+            name='test1', private=True, owner_org=org['id'])
+        dataset2 = factories.Dataset(name='test2')
+
+        user = factories.User()
+        context = {'user': user['name']}
+
+        results = toolkit.get_action('package_search')(context,
+                {'q':'*:*', 'include_private':True})
+
+        assert_equals(results['count'], 1)
+        assert_equals(results['results'][0]['id'], dataset2['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset1['id'], user_id=user['id'], capacity='member')
+
+        results = toolkit.get_action('package_search')(context,
+                {'q':'*:*', 'include_private':True, 'sort': 'name asc'})
+
+        assert_equals(results['count'], 2)
+
+        assert_equals(results['results'][0]['id'], dataset1['id'])
+        assert_equals(results['results'][1]['id'], dataset2['id'])

--- a/ckanext/collaborators/tests/test_auth.py
+++ b/ckanext/collaborators/tests/test_auth.py
@@ -1,7 +1,9 @@
 from nose.tools import assert_equals, assert_raises
 
 from ckan import model
-from ckan.plugins import toolkit
+from ckan.plugins import (
+    toolkit, plugin_loaded,
+    load as load_plugin, unload as unload_plugin)
 from ckan.tests import helpers, factories
 
 from ckanext.collaborators.tests import FunctionalTestBase
@@ -181,7 +183,9 @@ class TestCollaboratorsAuth(CollaboratorsAuthTestBase, FunctionalTestBase):
 
 class TestCollaboratorsShow(CollaboratorsAuthTestBase, FunctionalTestBase):
 
-    def test_show_private_dataset_editor(self):
+    _load_plugins = ['image_view']
+
+    def test_dataset_show_private_editor(self):
 
         org = factories.Organization()
         dataset = factories.Dataset(private=True, owner_org=org['id'])
@@ -199,7 +203,7 @@ class TestCollaboratorsShow(CollaboratorsAuthTestBase, FunctionalTestBase):
         assert helpers.call_auth('package_show',
             context=context, id=dataset['id'])
 
-    def test_show_private_dataset_member(self):
+    def test_dataset_show_private_member(self):
 
         org = factories.Organization()
         dataset = factories.Dataset(private=True, owner_org=org['id'])
@@ -216,3 +220,655 @@ class TestCollaboratorsShow(CollaboratorsAuthTestBase, FunctionalTestBase):
 
         assert helpers.call_auth('package_show',
             context=context, id=dataset['id'])
+
+    def test_resource_show_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_show',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_show',
+            context=context, id=resource['id'])
+
+    def test_resource_show_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_show',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert helpers.call_auth('resource_show',
+            context=context, id=resource['id'])
+
+    def test_resource_view_list_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_list',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_view_list',
+            context=context, id=resource['id'])
+
+    def test_resource_view_list_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_list',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert helpers.call_auth('resource_view_list',
+            context=context, id=resource['id'])
+
+    def test_resource_view_show_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        resource_view = factories.ResourceView(resource_id=resource['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        # Needed until ckan/ckan#4828 is backported
+        context['resource'] = model.Resource.get(resource['id'])
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_show',
+            context=context, id=resource_view['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_view_show',
+            context=context, id=resource_view['id'])
+
+    def test_resource_view_show_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        resource_view = factories.ResourceView(resource_id=resource['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        # Needed until ckan/ckan#4828 is backported
+        context['resource'] = model.Resource.get(resource['id'])
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_show',
+            context=context, id=resource_view['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert helpers.call_auth('resource_view_show',
+            context=context, id=resource_view['id'])
+
+    def test_resource_view_show_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_list',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_show',
+            context=context, id=resource['id'])
+
+
+class TestCollaboratorsUpdate(CollaboratorsAuthTestBase, FunctionalTestBase):
+
+    _load_plugins = ['image_view']
+
+    def test_dataset_update_public_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_update',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('package_update',
+            context=context, id=dataset['id'])
+
+    def test_dataset_update_public_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_update',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_update',
+            context=context, id=dataset['id'])
+
+
+    def test_dataset_update_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_update',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('package_update',
+            context=context, id=dataset['id'])
+
+    def test_dataset_update_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_update',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_update',
+            context=context, id=dataset['id'])
+
+    def test_dataset_delete_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_delete',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('package_delete',
+            context=context, id=dataset['id'])
+
+    def test_dataset_delete_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_delete',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_delete',
+            context=context, id=dataset['id'])
+
+    def test_resource_create_public_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_create',
+            context=context, package_id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_create',
+            context=context, package_id=dataset['id'])
+
+    def test_resource_create_public_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_create',
+            context=context, package_id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_create',
+            context=context, package_id=dataset['id'])
+
+    def test_resource_update_public_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_update',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_update',
+            context=context, id=resource['id'])
+
+    def test_resource_update_public_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_update',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_update',
+            context=context, id=resource['id'])
+
+    def test_resource_delete_public_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_delete',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_delete',
+            context=context, id=resource['id'])
+
+    def test_resource_delete_public_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_delete',
+            context=context, id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_delete',
+            context=context, id=resource['id'])
+
+    def test_resource_view_create_public_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_create',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('resource_view_create',
+            context=context, resource_id=resource['id'])
+
+    def test_resource_view_create_public_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_create',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'resource_view_create',
+            context=context, resource_id=resource['id'])
+
+
+class TestCollaboratorsDataStore(CollaboratorsAuthTestBase, FunctionalTestBase):
+
+    _load_plugins = ['datastore']
+
+    def test_datastore_search_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_search',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('datastore_search',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_search_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_search',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert helpers.call_auth('datastore_search',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_info_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_info',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('datastore_info',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_info_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_info',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert helpers.call_auth('datastore_info',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_search_sql_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        context['table_names'] = [resource['id']]
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_search_sql',
+            context=context, sql='SELECT * FROM "{}"'.format(resource['id']))
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('datastore_search_sql',
+            context=context, sql='SELECT * FROM "{}"'.format(resource['id']))
+
+    def test_datastore_search_sql_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        context['table_names'] = [resource['id']]
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_search_sql',
+            context=context, sql='SELECT * FROM "{}"'.format(resource['id']))
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert helpers.call_auth('datastore_search_sql',
+            context=context, sql='SELECT * FROM "{}"'.format(resource['id']))
+
+
+    def test_datastore_create_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_create',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('datastore_create',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_create_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_create',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_create',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_upsert_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_upsert',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('datastore_upsert',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_upsert_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_upsert',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_upsert',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_delete_private_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_delete',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('datastore_delete',
+            context=context, resource_id=resource['id'])
+
+    def test_datastore_delete_private_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_delete',
+            context=context, resource_id=resource['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'datastore_delete',
+            context=context, resource_id=resource['id'])

--- a/ckanext/collaborators/tests/test_auth.py
+++ b/ckanext/collaborators/tests/test_auth.py
@@ -177,3 +177,42 @@ class TestCollaboratorsAuth(CollaboratorsAuthTestBase, FunctionalTestBase):
         assert_raises(toolkit.NotAuthorized, helpers.call_auth,
             'dataset_collaborator_list_for_user',
             context=context, id=self.normal_user['id'])
+
+
+class TestCollaboratorsShow(CollaboratorsAuthTestBase, FunctionalTestBase):
+
+    def test_show_private_dataset_editor(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_show',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='editor')
+
+        assert helpers.call_auth('package_show',
+            context=context, id=dataset['id'])
+
+    def test_show_private_dataset_member(self):
+
+        org = factories.Organization()
+        dataset = factories.Dataset(private=True, owner_org=org['id'])
+        user = factories.User()
+
+        context = self._get_context(user)
+        assert_raises(toolkit.NotAuthorized, helpers.call_auth,
+            'package_show',
+            context=context, id=dataset['id'])
+
+        helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity='member')
+
+        assert helpers.call_auth('package_show',
+            context=context, id=dataset['id'])


### PR DESCRIPTION
Changes at the auth level to combine the collaborators-based auth with the org-based one, including

* `package_show / `package_search` via `IPermissionLabels`
* `package_update` plus all the other actions that rely on it at the dataset, resource, resource view and DataStore level

Adds extensive tests