### PR TITLE
Restrict collaborators altering organization

### DIFF
--- a/ckanext/collaborators/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/collaborators/templates/package/snippets/package_basic_fields.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+  {% block package_basic_fields_license %}
+  {% if not data.owner_org or h.user_in_org_or_group(data.owner_org) %}
+    {{ super() }}
+  {% endif %}
+  {% endblock %}
+
+  {% block package_basic_fields_org %} 
+  {% if not data.owner_org or h.user_in_org_or_group(data.owner_org) %}
+    {{ super() }}
+  {% endif %}
+  {% endblock %}


### PR DESCRIPTION
Partial fix for #11 

Updated dataset form basic fields to hide owner organization, license and visibility from non-owners (editor collaborators) 

