### PR TITLE
Fix collaborators_user_delete function

### DIFF
--- a/ckanext/collaborators/logic/action.py
+++ b/ckanext/collaborators/logic/action.py
@@ -227,10 +227,10 @@ def collaborators_user_delete(up_func, context, data_dict):
 
     model = context.get('model', core_model)
     up_func(context, data_dict)
-    id = data_dict['id']
+    user_id = data_dict['id']
 
     datasets_where_user_is_collaborator = model.Session.query(DatasetMember).filter(
-        DatasetMember.user_id == user.id).all()
+        DatasetMember.user_id == user_id).all()
     for collaborator in datasets_where_user_is_collaborator:
         model.Session.delete(collaborator)
 

--- a/ckanext/collaborators/tests/test_action.py
+++ b/ckanext/collaborators/tests/test_action.py
@@ -108,6 +108,23 @@ class TestCollaboratorsActions(FunctionalTestBase):
             'dataset_collaborator_delete',
             id=dataset['id'], user_id=user['id'])
 
+    def test_deleting_user_removes_collaborator(self):
+        dataset = factories.Dataset()
+        user = factories.User()
+        capacity = 'editor'
+
+        member = helpers.call_action(
+            'dataset_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity=capacity)
+
+        assert_equals(model.Session.query(DatasetMember).count(), 1)
+
+        helpers.call_action(
+            'user_delete',
+            id=user['id'])
+
+        assert_equals(model.Session.query(DatasetMember).count(), 0)
+
     def test_list(self):
 
         dataset = factories.Dataset()


### PR DESCRIPTION
This PR fixes a bug in `collaborators_user_delete` using a wrong global variable and adds a test for the new function.

```
======================================================================
ERROR: ckanext.collaborators.tests.test_action.TestCollaboratorsActions.test_deleting_user_removes_collaborator
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/srv/app/src_extensions/ckanext-collaborators/ckanext/collaborators/tests/test_action.py", line 124, in test_deleting_user_removes_collaborator
    id=user['id'])
  File "/srv/app/src/ckan/ckan/tests/helpers.py", line 109, in call_action
    return logic.get_action(action_name)(context=context, data_dict=kwargs)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 466, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src_extensions/ckanext-collaborators/ckanext/collaborators/logic/action.py", line 233, in collaborators_user_delete
    DatasetMember.user_id == user.id).all()
NameError: global name 'user' is not defined

```