### PR TITLE
Collaborator Email Notification: Add option

### DIFF
--- a/ckanext/collaborators/blueprint.py
+++ b/ckanext/collaborators/blueprint.py
@@ -69,7 +69,8 @@ class CollaboratorEditView(MethodView):
             data_dict = {
                 'id': dataset_id,
                 'user_id': user['id'],
-                'capacity': form_dict['capacity']
+                'capacity': form_dict['capacity'],
+                'send_mail': form_dict.get('send_mail', False)
             }
 
             toolkit.get_action('dataset_collaborator_create')(

--- a/ckanext/collaborators/logic/action.py
+++ b/ckanext/collaborators/logic/action.py
@@ -68,7 +68,8 @@ def dataset_collaborator_create(context, data_dict):
     log.info('User {} added as collaborator in dataset {} ({})'.format(
         user.name, dataset.id, capacity))
 
-    mail_notification_to_collaborator(dataset_id, user_id, capacity,
+    if data_dict.get('send_mail', False):
+        mail_notification_to_collaborator(dataset_id, user_id, capacity,
                                         event='create')
 
     return member.as_dict()

--- a/ckanext/collaborators/templates/collaborators/collaborator/collaborator_new.html
+++ b/ckanext/collaborators/templates/collaborators/collaborator/collaborator_new.html
@@ -41,6 +41,7 @@
 
     {% set format_attrs = {'data-module': 'autocomplete'} %}
     {{ form.select('capacity', label=_('Capacity'), options=capacities, selected=user_capacity, error='', attrs=format_attrs) }}
+    {{ form.checkbox('send_mail', label=_('Send a notification email?'), checked='True', value=True) }}
     <div class="form-actions">
       {% if user %}
         <a href="{{ h.url_for('collaborators.delete', dataset_id=pkg_dict.id, user_id=user.name) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this collaborator?') }}">{{ _('Delete') }}</a>


### PR DESCRIPTION
@amercader 

- [x] add a checkbox option to send or not email to the collaborator
- [x] create tests
- [x] create conditional to send or not email to the collaborator in action.py

Acceptance Criteria:

Given I want to add a Collaborator 

When I am on the Add Collaborator window

Than I have the option to check the checkbox labeled “Send a notification e-mail?” to Add Collaborator


**Tests:**

```
ckanext.collaborators.tests.test_action.TestCollaboratorsSearch.test_create_collaborator_emails_notification_if_not_send_email ... ok
ckanext.collaborators.tests.test_action.TestCollaboratorsSearch.test_create_collaborator_emails_notification_if_send_email ... ok
```

**Result:**

![Captura de tela de 2020-07-06 16-03-18](https://user-images.githubusercontent.com/24671133/86629775-44513000-bfa2-11ea-9bae-2425238c886a.png)


